### PR TITLE
Update passkey management and generation logic

### DIFF
--- a/app/common.py
+++ b/app/common.py
@@ -1,4 +1,5 @@
 import os, sys
+import winreg
 
 from logging import getLogger
 logger = getLogger(__name__)
@@ -22,3 +23,16 @@ def resource_path(relative_path: str) -> str:
     except Exception as e:
         logger.error(f"Error resolving resource path for {relative_path}: {e}")
         return None
+
+# PCのデバイスID（Windows: MachineGuid）を取得
+def get_device_id():
+    if os.name == "nt": # Windows
+        try:
+            reg = winreg.ConnectRegistry(None, winreg.HKEY_LOCAL_MACHINE)
+            key = winreg.OpenKey(reg, r"SOFTWARE\Microsoft\Cryptography")
+            value, _ = winreg.QueryValueEx(key, "MachineGuid")
+            return value
+        except Exception:
+            return "unknown"
+    else:
+        return "unknown"

--- a/app/host/window_api.py
+++ b/app/host/window_api.py
@@ -1,3 +1,4 @@
+from app.client.authenticator import get_current_passkey
 from app.host import host_config
 from app.host import version
 
@@ -38,10 +39,10 @@ class HomeApi:
 
 class ConnectApi:
     def get_current_passkey(self):
-        # 仮実装
+        passkey = get_current_passkey()
         return {
-            "passkey": "1234",
-            "remain": 25
+            "passkey": passkey["key"],
+            "remain": passkey["expire_in"]
         }
 
     def get_registered_devices(self):


### PR DESCRIPTION
We've revised the passkey generation algorithm to use device-specific information to generate a unique passkey.
Usability will remain unchanged.
Along with this, we've implemented a new method to get the device ID.
This will allow multiple processes to be isolated while still generating the same passkey. We'll be adjusting the API to reflect these changes.